### PR TITLE
Support for multiple pages added

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,137 @@
+use iced::{
+    text_input, Column, Element, Length, Row,
+    TextInput, Button, button, Text, Rule,
+};
+use csv::ReaderBuilder;
+use plotters::prelude::*;
+use plotters_iced::{Chart, ChartWidget, DrawingBackend};
+use std::collections::VecDeque;
+
+use super::{Message, WhichView};
+
+#[derive(Default)]
+pub struct Data {
+    chart: EcgChart,
+    device_input: text_input::State,
+    device_id: String,
+    ret_state: button::State,
+}
+
+impl Data {
+    pub fn new() -> Self {
+        Self { chart: EcgChart::new().unwrap(), ..Default::default() }
+    }
+
+    pub fn view(&mut self) -> Element<Message> {
+        let back = Button::new(
+            &mut self.ret_state,
+            Text::new("Back to menu").size(20),
+        ).on_press(Message::SwitchView(WhichView::Menu));
+
+        let header = Row::new()
+            .push(Text::new("Data"))
+            .push(Rule::horizontal(0))
+            .push(back);
+
+        let input = TextInput::new(
+            &mut self.device_input,
+            "Device ID",
+            &self.device_id,
+            Message::NewDeviceID,
+        )
+        .padding(15)
+        .size(20)
+        .on_submit(Message::CreateSensor);
+
+        // Data side
+        Column::new()
+            .spacing(20)
+            .width(Length::Fill)
+            .max_width(1000)
+            .push(header)
+            .push(Rule::horizontal(10))
+            .push(input)
+            .push(self.chart.view())
+            .into()
+    }
+
+    pub fn update_id(&mut self, msg: String) {
+        self.device_id = msg;
+    }
+
+    pub fn update(&mut self) {
+        self.chart.update();
+    }
+}
+
+// Store chart data
+#[derive(Default)]
+struct EcgChart {
+    data_points: VecDeque<(u64, f32)>,
+}
+
+impl EcgChart {
+    pub fn new() -> Result<EcgChart, Box<dyn std::error::Error>> {
+        let mut chart = Self::default();
+        chart.init_data()?;
+
+        Ok(chart)
+    }
+
+    // Draw chart
+    fn view(&mut self) -> Element<Message> {
+        let chart = ChartWidget::new(self)
+            .width(Length::Units(400))
+            .height(Length::Units(400));
+
+        chart.into()
+    }
+
+    // Get initial data from file
+    fn init_data(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let mut rdr = ReaderBuilder::new()
+            .flexible(true)
+            .from_path("output/test.csv")
+            .unwrap();
+
+        // skip extra header row
+        for record in rdr.records().skip(1) {
+            let result = record?;
+            self.data_points
+                .push_back((result[0].parse()?, result[1].parse::<f32>()? * 100.0));
+        }
+        Ok(())
+    }
+
+    // Update data - remove data from the end and add to the start
+    fn update(&mut self) {}
+}
+
+impl Chart<Message> for EcgChart {
+    // Create plotters chart
+    fn build_chart<DB: DrawingBackend>(&self, mut builder: ChartBuilder<DB>) {
+        let start = self.data_points[0].0;
+        let end = self.data_points.back().unwrap().0;
+
+        let mut ctx = builder
+            .set_label_area_size(LabelAreaPosition::Bottom, -181)
+            .set_label_area_size(LabelAreaPosition::Left, 40)
+            .caption("ECG Data", ("sans-serif", 30u32))
+            .build_cartesian_2d(0..100u64, -1000.0..1000.0f64)
+            .unwrap();
+
+        ctx.configure_mesh()
+            .set_tick_mark_size(LabelAreaPosition::Bottom, 5)
+            .draw()
+            .unwrap();
+
+        ctx.draw_series(LineSeries::new(
+            (start..end).map(|p| (p, self.data_points[(p - start) as usize].1 as f64)),
+            &BLACK,
+        ))
+        .expect("Error making graph");
+    }
+}
+
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,49 +1,75 @@
-use csv::ReaderBuilder;
 use iced::{
-    alignment, executor, text_input, Application, Column, Command, Element, Length, Subscription,
-    Text, TextInput, Row, Rule, Button, button,
+    alignment, executor, Application, Column, Command, Element, Length, Subscription, Text, Rule,
 };
-use plotters::prelude::*;
-use plotters_iced::{Chart, ChartWidget, DrawingBackend};
-use std::collections::VecDeque;
-
 use std::time;
-use chrono::{DateTime, Utc};
 
 mod blue;
+mod menu;
+mod data;
+
+use menu::{Menu, WhichMeta};
+use data::Data;
 
 #[derive(Default)]
-pub struct Menu {
-    device_input: text_input::State,
-    device_id: String,
+pub struct App {
     sensor: Option<()>, // TODO - fill with actual arctic sensor when update is made
-    chart: EcgChart,
-    meta_state: MetaState,
+    view: Views,
+}
+
+pub enum Views {
+    Menu(Box<Menu>),
+    Data(Box<Data>),
+}
+
+impl Views {
+    fn view(&mut self) -> Element<Message> {
+        match self {
+            Views::Menu(menu) => menu.view(),
+            Views::Data(data) => data.view(),
+        }
+    }
+}
+
+impl Default for Views {
+    fn default() -> Self {
+        Views::Menu(Box::new(Menu::new()))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum WhichView {
+    Menu,
+    Data,
+}
+
+impl From<WhichView> for Views {
+    fn from(which: WhichView) -> Self {
+        match which {
+            WhichView::Menu => Views::Menu(Box::new(Menu::default())),
+            WhichView::Data => Views::Data(Box::new(Data::new())),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
     None,
     Tick,
-    InputChanged(String),
+    NewDeviceID(String),
     CreateSensor,
     NewMeta,
     ChangeMeta(WhichMeta, String),
+    SwitchView(WhichView),
 }
 
-impl Application for Menu {
+impl Application for App {
     type Executor = executor::Default;
     type Message = Message;
     type Flags = ();
 
     fn new(_flags: ()) -> (Self, Command<Message>) {
-        let chart = EcgChart::new().expect("Error making graph.");
-
         (
-            Menu {
-                chart,
-                ..Default::default()
-            },
+            App::default(),
             Command::none(),
         )
     }
@@ -55,22 +81,35 @@ impl Application for Menu {
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::None => {}
-            Message::Tick => {}
-            Message::InputChanged(msg) => {
-                self.device_id = msg;
+            Message::Tick => {
+                if let Views::Data(data) = &mut self.view {
+                    data.update();
+                }
+            }
+            Message::NewDeviceID(msg) => {
+                if let Views::Data(data) = &mut self.view {
+                    data.update_id(msg);
+                }
             }
             Message::CreateSensor => {
                 // Construct sensor
                 println!("Sensor created!");
             }
-            Message::NewMeta => {}
-            Message::ChangeMeta(which, msg) => {
-                match which {
-                    WhichMeta::Id => self.meta_state.meta_data.id = msg,
-                    WhichMeta::Session => self.meta_state.meta_data.session = msg,
-                    WhichMeta::Trial => self.meta_state.meta_data.trial = msg,
-                    WhichMeta::Description => self.meta_state.meta_data.description = msg,
+            Message::NewMeta => {
+                if let Views::Menu(meta) = &mut self.view {
+                    if meta.verify().is_ok() {
+                        self.update(Message::SwitchView(WhichView::Data));
+                    }
                 }
+                // TODO - Update output file here
+            }
+            Message::ChangeMeta(which, msg) => {
+                if let Views::Menu(meta) = &mut self.view {
+                    meta.change_data(which, msg);
+                }
+            }
+            Message::SwitchView(view) => {
+                self.view = view.into();
             }
         }
 
@@ -81,218 +120,20 @@ impl Application for Menu {
         iced::time::every(time::Duration::from_millis(16)).map(|_| Message::Tick)
     }
 
+
     fn view(&mut self) -> Element<'_, Message> {
         let title = Text::new("Polar-Arctic")
             .width(Length::Fill)
             .size(60)
             .horizontal_alignment(alignment::Horizontal::Center);
 
-        let input = TextInput::new(
-            &mut self.device_input,
-            "Device ID",
-            &self.device_id,
-            Message::InputChanged,
-        )
-        .padding(15)
-        .size(25)
-        .on_submit(Message::CreateSensor);
-
-        let testing = Text::new(&self.device_id).size(25).width(Length::Fill);
-
-        // Data side
-        let left = Column::new()
-            .spacing(20)
-            .width(Length::Fill)
-            .max_width(1000)
-            .push(input)
-            .push(testing)
-            .push(self.chart.view());
-
-
-        let meta_header = Text::new("Meta")
-            .width(Length::Fill)
-            .size(40);
-
-        // meta side
-        let right = Column::new()
-            .spacing(20)
-            .width(Length::Fill)
-            .max_width(1000)
-            .push(meta_header)
-            .push(self.meta_state.view());
-
-
-        // full view
-        let body = Row::new()
-            .spacing(20)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .push(left)
-            .push(Rule::vertical(2))
-            .push(right);
+        let body = self.view.view();
 
         Column::new()
             .push(title)
+            .push(Rule::horizontal(10))
             .push(body)
             .into()
     }
 }
 
-// Store chart data
-#[derive(Default)]
-struct EcgChart {
-    data_points: VecDeque<(u64, f32)>,
-}
-
-impl EcgChart {
-    pub fn new() -> Result<EcgChart, Box<dyn std::error::Error>> {
-        let mut chart = Self::default();
-        chart.init_data()?;
-
-        Ok(chart)
-    }
-
-    // Draw chart
-    fn view(&mut self) -> Element<Message> {
-        let chart = ChartWidget::new(self)
-            .width(Length::Units(400))
-            .height(Length::Units(400));
-
-        chart.into()
-    }
-
-    // Get initial data from file
-    fn init_data(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let mut rdr = ReaderBuilder::new()
-            .flexible(true)
-            .from_path("output/test.csv")
-            .unwrap();
-
-        // skip extra header row
-        for record in rdr.records().skip(1) {
-            let result = record?;
-            self.data_points
-                .push_back((result[0].parse()?, result[1].parse::<f32>()? * 100.0));
-        }
-
-        Ok(())
-    }
-
-    // Update data - remove data from the end and add to the start
-    fn update(&mut self) {}
-}
-
-impl Chart<Message> for EcgChart {
-    // Create plotters chart
-    fn build_chart<DB: DrawingBackend>(&self, mut builder: ChartBuilder<DB>) {
-        let start = self.data_points[0].0;
-        let end = self.data_points.back().unwrap().0;
-
-        let mut ctx = builder
-            .set_label_area_size(LabelAreaPosition::Bottom, -181)
-            .set_label_area_size(LabelAreaPosition::Left, 40)
-            .caption("ECG Data", ("sans-serif", 30u32))
-            .build_cartesian_2d(0..100u64, -1000.0..1000.0f64)
-            .unwrap();
-
-        ctx.configure_mesh()
-            .set_tick_mark_size(LabelAreaPosition::Bottom, 5)
-            .draw()
-            .unwrap();
-
-        ctx.draw_series(LineSeries::new(
-            (start..end).map(|p| (p, self.data_points[(p - start) as usize].1 as f64)),
-            &BLACK,
-        ))
-        .expect("Error making graph");
-    }
-}
-
-// Store meta-data about this run
-struct Meta {
-    pub id: String,
-    pub session: String,
-    pub trial: String,
-    pub description: String,
-    pub date: DateTime<Utc>,
-}
-
-impl Default for Meta {
-    fn default() -> Self {
-        Meta {
-            id: "".to_string(),
-            session: "".to_string(),
-            trial: "".to_string(),
-            description: "".to_string(),
-            date: Utc::now(),
-        }
-    }
-}
-
-// Which kind of metadata to change 
-#[derive(Debug, Clone, Copy)]
-pub enum WhichMeta {
-    Id,
-    Session,
-    Trial,
-    Description,
-}
-
-// Store states for meta data
-#[derive(Default)]
-struct MetaState {
-    id_state: text_input::State,
-    session_state: text_input::State,
-    trial_state: text_input::State,
-    description_state: text_input::State,
-    submit_state: button::State,
-    pub meta_data: Meta,
-}
-
-impl MetaState {
-    fn view(&mut self) -> Element<Message> {
-        let id = TextInput::new(
-            &mut self.id_state,
-            "Participant ID",
-            &self.meta_data.id,
-            |s| Message::ChangeMeta(WhichMeta::Id, s),
-        );
-
-        let session = TextInput::new(
-            &mut self.session_state,
-            "Session Number",
-            &self.meta_data.session,
-            |s| Message::ChangeMeta(WhichMeta::Session, s),
-        );
-
-        let trial = TextInput::new(
-            &mut self.trial_state,
-            "Trial number",
-            &self.meta_data.trial,
-            |s| Message::ChangeMeta(WhichMeta::Trial, s),
-        );
-
-        let description = TextInput::new(
-            &mut self.description_state,
-            "Description/Notes",
-            &self.meta_data.description,
-            |s| Message::ChangeMeta(WhichMeta::Description, s),
-        );
-
-        let submit = Button::new(
-            &mut self.submit_state, 
-            Text::new("Submit"),
-        ).on_press(Message::NewMeta);
-
-        Column::new()
-            .spacing(20)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .push(id)
-            .push(session)
-            .push(trial)
-            .push(description)
-            .push(submit)
-            .into()
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use back::Menu;
+use back::App;
 use iced::Application;
 use iced::Settings;
 
 fn main() -> iced::Result {
-    Menu::run(Settings::default())
+    App::run(Settings::default())
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,0 +1,148 @@
+use iced::{
+    text_input, Column, Element, Length,
+    Text, TextInput, Button, button,
+};
+use super::Message;
+use chrono::{DateTime, Utc};
+
+#[derive(Default)]
+pub struct Menu {
+    meta_state: MetaState,
+}
+
+impl Menu {
+    pub fn new() -> Self {
+        Self { meta_state: MetaState::default() }
+    }
+
+    pub fn state(&mut self) -> &mut MetaState {
+        &mut self.meta_state
+    }
+
+    pub fn view(&mut self) -> Element<Message> {
+        let title = Text::new("Metadata")
+            .size(30);
+
+        Column::new()
+            .push(title)
+            .push(self.meta_state.view())
+            .into()
+    }
+
+    pub fn change_data(&mut self, which: WhichMeta, msg: String) {
+        match which {
+            WhichMeta::Id => self.state().meta_data.id = msg,
+            WhichMeta::Session => self.state().meta_data.session = msg,
+            WhichMeta::Trial => self.state().meta_data.trial = msg,
+            WhichMeta::Description => self.state().meta_data.description = msg,
+        }
+    }
+
+    pub fn verify(&mut self) -> Result<(), WhichMeta> {
+        let meta = &mut self.meta_state.meta_data;
+
+        if meta.id.is_empty() {
+            return Err(WhichMeta::Id);
+        }
+        if meta.session.is_empty() {
+            return Err(WhichMeta::Session);
+        }
+        if meta.trial.is_empty() {
+            return Err(WhichMeta::Trial);
+        }
+        if meta.description.is_empty() {
+            return Err(WhichMeta::Description);
+        }
+
+        Ok(())
+    }
+}
+
+// Store meta-data about this run
+pub struct Meta {
+    pub id: String,
+    pub session: String,
+    pub trial: String,
+    pub description: String,
+    pub date: DateTime<Utc>,
+}
+
+impl Default for Meta {
+    fn default() -> Self {
+        Meta {
+            id: "".to_string(),
+            session: "".to_string(),
+            trial: "".to_string(),
+            description: "".to_string(),
+            date: Utc::now(),
+        }
+    }
+}
+
+// Which kind of metadata to change 
+#[derive(Debug, Clone, Copy)]
+pub enum WhichMeta {
+    Id,
+    Session,
+    Trial,
+    Description,
+}
+
+// Store states for meta data
+#[derive(Default)]
+pub struct MetaState {
+    id_state: text_input::State,
+    session_state: text_input::State,
+    trial_state: text_input::State,
+    description_state: text_input::State,
+    submit_state: button::State,
+    pub meta_data: Meta,
+}
+
+impl MetaState {
+    fn view(&mut self) -> Element<Message> {
+        let id = TextInput::new(
+            &mut self.id_state,
+            "Participant ID",
+            &self.meta_data.id,
+            |s| Message::ChangeMeta(WhichMeta::Id, s),
+        );
+
+        let session = TextInput::new(
+            &mut self.session_state,
+            "Session Number",
+            &self.meta_data.session,
+            |s| Message::ChangeMeta(WhichMeta::Session, s),
+        );
+
+        let trial = TextInput::new(
+            &mut self.trial_state,
+            "Trial number",
+            &self.meta_data.trial,
+            |s| Message::ChangeMeta(WhichMeta::Trial, s),
+        );
+
+        let description = TextInput::new(
+            &mut self.description_state,
+            "Description/Notes",
+            &self.meta_data.description,
+            |s| Message::ChangeMeta(WhichMeta::Description, s),
+        );
+
+        let submit = Button::new(
+            &mut self.submit_state, 
+            Text::new("Submit"),
+        ).on_press(Message::NewMeta);
+
+        Column::new()
+            .spacing(20)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .push(id)
+            .push(session)
+            .push(trial)
+            .push(description)
+            .push(submit)
+            .into()
+    }
+}


### PR DESCRIPTION
# Motivation

Create a more intuitive UI by separating meta data, and runtime controls into different pages. Fixed #2 

# Solution

Have the app store an enum `Views` that can either be `Meta` or `Data`, and render each view differently.